### PR TITLE
[R] Avoid using symlinks to be compatible in windows

### DIFF
--- a/R/inst/data/config.json
+++ b/R/inst/data/config.json
@@ -1,1 +1,6 @@
-../../../common/config.json
+{
+  "dirs": {
+    "unix":   "~/spark",
+    "windows": "%LOCALAPPDATA%/spark"
+  }
+}

--- a/R/inst/data/versions.json
+++ b/R/inst/data/versions.json
@@ -1,1 +1,194 @@
-../../../common/versions.json
+[
+  {
+    "spark": "1.5.2",
+    "hadoop": "2.6",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "1.5.2",
+    "hadoop": "2.4",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "1.5.2",
+    "hadoop": "2.3",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "1.5.2",
+    "hadoop": "cdh4",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-%s.tgz"
+  },
+  {
+    "spark": "1.6.2",
+    "hadoop": "2.6",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "1.6.2",
+    "hadoop": "2.4",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "1.6.2",
+    "hadoop": "2.3",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "1.6.2",
+    "hadoop": "cdh4",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-%s.tgz"
+  },
+  {
+    "spark": "1.6.1",
+    "hadoop": "2.6",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "1.6.1",
+    "hadoop": "2.4",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "1.6.1",
+    "hadoop": "2.3",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "1.6.1",
+    "hadoop": "cdh4",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-%s.tgz"
+  },
+  {
+    "spark": "1.6.0",
+    "hadoop": "2.6",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "1.6.0",
+    "hadoop": "2.4",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "1.6.0",
+    "hadoop": "2.3",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "1.6.0",
+    "hadoop": "cdh4",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-%s.tgz"
+  },
+  {
+    "spark": "2.0.0",
+    "hadoop": "2.7",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.0.0",
+    "hadoop": "2.6",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.0.0",
+    "hadoop": "2.4",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.0.0",
+    "hadoop": "2.3",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.0.1",
+    "hadoop": "2.7",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.0.1",
+    "hadoop": "2.6",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.0.1",
+    "hadoop": "2.4",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.0.1",
+    "hadoop": "2.3",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.0.2",
+    "hadoop": "2.7",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.0.2",
+    "hadoop": "2.6",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.0.2",
+    "hadoop": "2.4",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.0.2",
+    "hadoop": "2.3",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.1.0",
+    "hadoop": "2.7",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.1.0",
+    "hadoop": "2.6",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.1.0",
+    "hadoop": "2.4",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.1.0",
+    "hadoop": "2.3",
+    "base": "https://d3kbcqa49mib13.cloudfront.net/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  }
+]


### PR DESCRIPTION
If the package is built from windows using `devtools`, the symlinks to the config file are not resolved and operations will fail. We can revert this change once we publish to CRAN.