### PR TITLE
[Py] Fixed license and category in setup.py

### DIFF
--- a/Python/setup.py
+++ b/Python/setup.py
@@ -37,10 +37,9 @@ setup(
         # Indicate who your project is intended for
         'Intended Audience :: Developers',
         'Topic :: Software Development',
-        'Topic :: Build Tools',
 
         # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: Apache',
+        'License :: OSI Approved :: Apache Software License',
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.


### PR DESCRIPTION
The license field was invalid and was rejected by PyPI so I checked in the correct version. 