### PR TITLE
Bugfix/spark 2.4.4

### DIFF
--- a/R/inst/extdata/versions.json
+++ b/R/inst/extdata/versions.json
@@ -23,7 +23,7 @@
     "base": "https://d3kbcqa49mib13.cloudfront.net/",
     "pattern": "spark-%s-bin-%s.tgz"
   },
-    {
+  {
     "spark": "1.6.3",
     "hadoop": "2.6",
     "base": "https://d3kbcqa49mib13.cloudfront.net/",
@@ -273,6 +273,102 @@
     "spark": "2.3.0",
     "hadoop": "2.6",
     "base": "https://archive.apache.org/dist/spark/spark-2.3.0/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.3.1",
+    "hadoop": "2.7",
+    "base": "https://archive.apache.org/dist/spark/spark-2.3.1/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.3.1",
+    "hadoop": "2.6",
+    "base": "https://archive.apache.org/dist/spark/spark-2.3.1/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.3.2",
+    "hadoop": "2.7",
+    "base": "https://archive.apache.org/dist/spark/spark-2.3.2/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.3.2",
+    "hadoop": "2.6",
+    "base": "https://archive.apache.org/dist/spark/spark-2.3.2/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.3.3",
+    "hadoop": "2.7",
+    "base": "https://archive.apache.org/dist/spark/spark-2.3.3/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.3.3",
+    "hadoop": "2.6",
+    "base": "https://archive.apache.org/dist/spark/spark-2.3.3/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.4.0",
+    "hadoop": "2.7",
+    "base": "https://archive.apache.org/dist/spark/spark-2.4.0/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.4.0",
+    "hadoop": "2.6",
+    "base": "https://archive.apache.org/dist/spark/spark-2.4.0/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.4.1",
+    "hadoop": "2.7",
+    "base": "https://archive.apache.org/dist/spark/spark-2.4.1/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.4.1",
+    "hadoop": "2.6",
+    "base": "https://archive.apache.org/dist/spark/spark-2.4.1/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.4.2",
+    "hadoop": "2.7",
+    "base": "https://archive.apache.org/dist/spark/spark-2.4.2/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.4.2",
+    "hadoop": "2.6",
+    "base": "https://archive.apache.org/dist/spark/spark-2.4.2/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.4.3",
+    "hadoop": "2.7",
+    "base": "https://archive.apache.org/dist/spark/spark-2.4.3/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.4.3",
+    "hadoop": "2.6",
+    "base": "https://archive.apache.org/dist/spark/spark-2.4.3/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.4.4",
+    "hadoop": "2.7",
+    "base": "https://archive.apache.org/dist/spark/spark-2.4.4/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.4.4",
+    "hadoop": "2.6",
+    "base": "https://archive.apache.org/dist/spark/spark-2.4.4/",
     "pattern": "spark-%s-bin-hadoop%s.tgz"
   }
 ]

--- a/common/versions.json
+++ b/common/versions.json
@@ -358,5 +358,17 @@
     "hadoop": "2.6",
     "base": "https://archive.apache.org/dist/spark/spark-2.4.3/",
     "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.4.4",
+    "hadoop": "2.7",
+    "base": "https://archive.apache.org/dist/spark/spark-2.4.4/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "2.4.4",
+    "hadoop": "2.6",
+    "base": "https://archive.apache.org/dist/spark/spark-2.4.4/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
   }
 ]


### PR DESCRIPTION
This PR adds support for Spark 2.4.4 by adding it to the versions.js file. I've model this PR on similar PRs that added support for new versions of spark like #38 .

In addition to this I've also updated the versions.js that lives in the R package so that it is up to date with the common/versions.js.